### PR TITLE
Instrucoes de configuracao do ambiente para Windows

### DIFF
--- a/howto/windows/01a-install-openjdk21-winget.md
+++ b/howto/windows/01a-install-openjdk21-winget.md
@@ -1,0 +1,49 @@
+### Instalação do OpenJDK 21 no Windows via winget
+
+Executar os seguintes comandos no PowerShell para instalar o OpenJDK 21 no Windows:
+
+1. **Instalar o OpenJDK 21**
+
+```powershell
+winget install Microsoft.OpenJDK.21
+```
+
+2. **Fechar o PowerShell e abrir uma janela nova**
+
+O PATH só é recarregado em uma sessão nova do terminal.
+
+3. **Verificar a instalação**
+
+```powershell
+java -version
+javac -version
+```
+
+4. **Confirmar a instalação**
+
+```powershell
+openjdk version "21.0.12" 2026-07-21 LTS
+OpenJDK Runtime Environment Microsoft-14653896 (build 21.0.12+8-LTS)
+OpenJDK 64-Bit Server VM Microsoft-14653896 (build 21.0.12+8-LTS, mixed mode, sharing)
+javac 21.0.12
+```
+
+5. **Configurar o OpenJDK 21 como padrão**
+
+Esse passo é necessário apenas caso tenha várias versões do Java instaladas. No Windows não existe o `update-alternatives`, a versão padrão é definida pela ordem das entradas no PATH.
+
+Verificar qual executável está sendo chamado primeiro:
+
+```powershell
+where.exe java
+```
+
+A primeira linha da saída é a versão em uso. Se ela apontar para uma instalação antiga, remover a entrada correspondente do PATH:
+
+* Tecla Windows, buscar "variáveis de ambiente"
+* Abrir "Editar as variáveis de ambiente do sistema"
+* Botão "Variáveis de Ambiente"
+* Em "Variáveis do sistema", selecionar `Path` e clicar em Editar
+* Excluir a linha da instalação antiga (exemplo: `C:\ProgramData\Oracle\Java\javapath`)
+* Confirmar que existe a linha `C:\Program Files\Microsoft\jdk-21.x.x-hotspot\bin`
+* Confirmar com OK, fechar o PowerShell e abrir uma janela nova

--- a/howto/windows/01b-install-openjdk21-manual-windows.md
+++ b/howto/windows/01b-install-openjdk21-manual-windows.md
@@ -1,0 +1,35 @@
+### Instalação manual do OpenJDK 21 no Windows
+
+Alternativa para os casos em que o winget não está disponível ou falha.
+
+1. **Baixar o instalador**
+
+Acessar https://learn.microsoft.com/java/openjdk/download e baixar o arquivo `.msi` do JDK 21 para a arquitetura x64.
+
+2. **Executar o instalador**
+
+Na tela de opções, marcar as opções abaixo:
+
+* Add to PATH
+* Set JAVA_HOME variable
+
+3. **Fechar o PowerShell e abrir uma janela nova**
+
+4. **Verificar a instalação**
+
+```powershell
+java -version
+javac -version
+```
+
+5. **Verificar a variável JAVA_HOME**
+
+```powershell
+$env:JAVA_HOME
+```
+
+Saída esperada:
+
+```powershell
+C:\Program Files\Microsoft\jdk-21.0.12.8-hotspot
+```

--- a/howto/windows/01c-install-openjdk21-scoop.md
+++ b/howto/windows/01c-install-openjdk21-scoop.md
@@ -1,0 +1,42 @@
+### Instalação do OpenJDK 21 no Windows via Scoop
+
+O SDKMAN não funciona no Windows nativo. O gerenciador equivalente é o Scoop, que permite instalar e alternar entre várias versões do JDK.
+
+Use este método apenas se precisar manter mais de uma versão do Java na máquina. Para a disciplina, a instalação via winget é suficiente.
+
+1. **Habilitar a execução de scripts no PowerShell**
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+2. **Instalar o Scoop**
+
+```powershell
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+```
+
+3. **Adicionar o repositório de pacotes Java**
+
+```powershell
+scoop bucket add java
+```
+
+4. **Instalar o OpenJDK 21**
+
+```powershell
+scoop install openjdk21
+```
+
+5. **Verificar a instalação**
+
+```powershell
+java -version
+javac -version
+```
+
+6. **Alternar entre versões instaladas**
+
+```powershell
+scoop reset openjdk21
+```

--- a/howto/windows/01d-install-gh-windows.md
+++ b/howto/windows/01d-install-gh-windows.md
@@ -1,0 +1,36 @@
+### Instalação do gh no Windows
+
+1. **Instalar o GitHub CLI (https://cli.github.com/)**
+
+```powershell
+winget install GitHub.cli
+```
+
+2. **Fechar o PowerShell e abrir uma janela nova**
+
+3. **Verificar a instalação**
+
+```powershell
+gh --version
+```
+
+4. **Autenticar**
+
+```powershell
+gh auth login
+```
+
+Responder às perguntas na seguinte ordem:
+
+* Where do you use GitHub? → `GitHub.com`
+* What is your preferred protocol? → `HTTPS`
+* Authenticate Git with your GitHub credentials? → `Y`
+* How would you like to authenticate? → `Login with a web browser`
+
+O código de autorização no formato `XXXX-XXXX` é exibido no próprio terminal, na linha imediatamente anterior ao aviso de abertura do navegador. Copiar o código antes de pressionar Enter.
+
+5. **Verificar**
+
+```powershell
+gh auth status
+```

--- a/howto/windows/01e-install-git-windows.md
+++ b/howto/windows/01e-install-git-windows.md
@@ -1,0 +1,38 @@
+### Instalação do Git no Windows
+
+1. **Instalar o Git (https://git-scm.com/)**
+
+```powershell
+winget install Git.Git
+```
+
+2. **Fechar o PowerShell e abrir uma janela nova**
+
+3. **Verificar a instalação**
+
+```powershell
+git --version
+```
+
+4. **Configurar identidade**
+
+Utilizar o mesmo endereço de email da conta do GitHub, caso contrário os commits não são atribuídos ao perfil correto.
+
+```powershell
+git config --global user.name "Seu Nome"
+git config --global user.email "seu-email@dominio.com"
+```
+
+5. **Configurar o tratamento de quebra de linha**
+
+O Windows utiliza CRLF e o repositório utiliza LF. Sem esta configuração, arquivos inteiros aparecem como modificados no `git diff` mesmo sem alteração de conteúdo.
+
+```powershell
+git config --global core.autocrlf true
+```
+
+6. **Verificar a configuração**
+
+```powershell
+git config --global --list
+```

--- a/howto/windows/01f-install-git-lfs-windows.md
+++ b/howto/windows/01f-install-git-lfs-windows.md
@@ -1,0 +1,21 @@
+### Instalação do Git LFS no Windows
+
+1. **Instalar o Git LFS**
+
+```powershell
+winget install GitHub.GitLFS
+```
+
+2. **Fechar o PowerShell e abrir uma janela nova**
+
+3. **Habilitar o Git LFS para o usuário**
+
+```powershell
+git lfs install
+```
+
+4. **Verificar a instalação**
+
+```powershell
+git lfs version
+```

--- a/howto/windows/01g-install-docker-windows.md
+++ b/howto/windows/01g-install-docker-windows.md
@@ -1,0 +1,46 @@
+### Instalação do Docker no Windows
+
+O Docker é necessário a partir do módulo de JDBC, para executar o PostgreSQL com o banco de dados `dvdrental`.
+
+1. **Instalar o Docker Desktop**
+
+```powershell
+winget install Docker.DockerDesktop
+```
+
+2. **Reiniciar o computador**
+
+O Docker Desktop utiliza o WSL2 e habilita o componente durante a instalação.
+
+3. **Abrir o Docker Desktop**
+
+Aguardar até o ícone da baleia indicar que o serviço está em execução.
+
+4. **Verificar a instalação**
+
+```powershell
+docker --version
+docker run hello-world
+```
+
+5. **Executar o PostgreSQL**
+
+```powershell
+docker run --name pg-idp -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:16
+```
+
+6. **Restaurar o banco dvdrental**
+
+Baixar o arquivo `dvdrental.zip`, extrair o `dvdrental.tar` e executar:
+
+```powershell
+docker cp dvdrental.tar pg-idp:/tmp/
+docker exec -it pg-idp createdb -U postgres dvdrental
+docker exec -it pg-idp pg_restore -U postgres -d dvdrental /tmp/dvdrental.tar
+```
+
+7. **Verificar a restauração**
+
+```powershell
+docker exec -it pg-idp psql -U postgres -d dvdrental -c "SELECT count(*) FROM film;"
+```

--- a/howto/windows/02a-install-vscode-winget.md
+++ b/howto/windows/02a-install-vscode-winget.md
@@ -1,0 +1,37 @@
+### Instalar o VS Code no Windows via winget
+
+1. **Instalar o VS Code**
+
+```powershell
+winget install Microsoft.VisualStudioCode
+```
+
+2. **Fechar o PowerShell e abrir uma janela nova**
+
+3. **Verificar instalação**
+
+```powershell
+code --version
+```
+
+4. **Confirmar instalação**
+
+```powershell
+1.96.4
+cd4ee3b1c348a13bafd8f9ad8060705f6d4b9cba
+x64
+```
+
+5. **Instalar as extensões de Java**
+
+```powershell
+code --install-extension vscjava.vscode-java-pack
+```
+
+6. **Confirmar as extensões instaladas**
+
+```powershell
+code --list-extensions | Select-String java
+```
+
+A saída deve conter `vscjava.vscode-java-pack` e as extensões que acompanham o pacote.

--- a/howto/windows/02b-install-vscode-manual-windows.md
+++ b/howto/windows/02b-install-vscode-manual-windows.md
@@ -1,0 +1,31 @@
+### Instalar o VS Code no Windows manualmente
+
+Alternativa para os casos em que o winget não está disponível ou falha.
+
+1. **Baixar o instalador**
+
+Acessar https://code.visualstudio.com/download e baixar o instalador para Windows x64 (User Installer).
+
+2. **Executar o instalador**
+
+Na tela "Selecionar tarefas adicionais", marcar as opções abaixo:
+
+* Adicionar a ação "Abrir com Code" ao menu de contexto de arquivo do Windows Explorer
+* Adicionar a ação "Abrir com Code" ao menu de contexto de diretório do Windows Explorer
+* Adicionar ao PATH
+
+A última opção é obrigatória para que o comando `code` funcione no terminal.
+
+3. **Fechar o PowerShell e abrir uma janela nova**
+
+4. **Verificar instalação**
+
+```powershell
+code --version
+```
+
+5. **Instalar as extensões de Java**
+
+```powershell
+code --install-extension vscjava.vscode-java-pack
+```

--- a/howto/windows/03a-prepare-repo-windows.md
+++ b/howto/windows/03a-prepare-repo-windows.md
@@ -1,0 +1,42 @@
+### Preparar repositório da disciplina no Windows
+
+* Navegar até o diretório onde os projetos são armazenados, pois o clone ocorre no diretório atual
+
+```powershell
+cd C:\Users\seu-usuario\projetos
+```
+
+* Realizar fork do repositório da disciplina e clonar em uma única operação
+
+```powershell
+gh repo fork fabriciosantana/poo --clone
+```
+
+* Entrar no diretório e selecionar a branch da disciplina
+
+```powershell
+cd poo
+git checkout 2026.2
+```
+
+* Verificar os repositórios remotos
+
+```powershell
+git remote -v
+```
+
+O remoto `origin` deve apontar para o seu usuário e o `upstream` para `fabriciosantana`. Caso o `origin` aponte para o repositório do professor, o fork não foi criado e o push não será permitido.
+
+```powershell
+origin    https://github.com/seu-usuario/poo.git (fetch)
+origin    https://github.com/seu-usuario/poo.git (push)
+upstream  https://github.com/fabriciosantana/poo.git (fetch)
+upstream  https://github.com/fabriciosantana/poo.git (push)
+```
+
+* Atualizar o repositório local com as alterações publicadas pelo professor durante o semestre
+
+```powershell
+git fetch upstream
+git merge upstream/2026.2
+```

--- a/howto/windows/03a-submit-assignments-windows.md
+++ b/howto/windows/03a-submit-assignments-windows.md
@@ -1,0 +1,27 @@
+### Instruções gerais para entrega das atividades no Windows
+
+* Criar um diretório com seu nome e sobrenome dentro do diretório da atividade (o nome do último diretório deve ser seu nome e sobrenome em caixa baixa)
+
+```powershell
+New-Item -ItemType Directory -Force -Path assignments\00-hello\submissions\fabricio-santana\src
+```
+
+* Desenvolver programa Java dentro do seu diretório atendendo os requisitos da especificação e os requisitos de implementação
+
+* Comitar alterações em seu repositório
+
+```powershell
+git add .
+git commit -m "minha solução da tarefa"
+git push
+```
+
+* Enviar um pull request
+
+```powershell
+gh pr create --base 2026.2 --head seu-usuario:2026.2 --title "Minha tarefa XXX" --body "Descrição das alterações realizadas."
+```
+
+* Observar se os testes do pull request rodaram com sucesso
+* Submeter link do pull request no [ambiente virtual](https://ambientevirtual.idp.edu.br/)
+* Cumprir prazo de entrega conforme ambiente virtual

--- a/howto/windows/03b-submit-readings-windows.md
+++ b/howto/windows/03b-submit-readings-windows.md
@@ -1,0 +1,22 @@
+### Procedimento para entrega das leituras no Windows
+
+* Escrever manualmente o resumo em folha A4 branca
+* Fazer fork do repositório da disciplina
+* Digitalizar em PDF e gravar no diretório `readings\NN-XXXX\seunome-seusobrenome.pdf`
+* Fazer commit e push
+
+```powershell
+git add .
+git commit -m "entrega da leitura NN"
+git push
+```
+
+* Enviar pull request
+
+```powershell
+gh pr create --base 2026.2 --head seu-usuario:2026.2 --title "Leitura NN" --body "Entrega do resumo da leitura NN."
+```
+
+* Submeter link do pull request no [Ambiente Virtual](https://ambientevirtual.idp.edu.br/)
+* Entregar o resumo físico em mãos na sala de aula
+* Respeitar o prazo para cada texto de acordo com o prazo definido no ambiente virtual e acordado em sala

--- a/howto/windows/04a-run-java-program-windows.md
+++ b/howto/windows/04a-run-java-program-windows.md
@@ -1,0 +1,52 @@
+### Como compilar, empacotar, decompilar e executar programa java na linha de comando no Windows
+
+Execute os comandos abaixo no PowerShell para compilar, empacotar, decompilar e executar programa java na linha de comando.
+
+Duas diferenças em relação ao Linux devem ser observadas:
+
+* O PowerShell não expande curingas como `src\*.java` para programas externos. A lista de arquivos precisa ser montada antes da chamada ao `javac`
+* O separador entre entradas de classpath é o ponto e vírgula (`;`) e não os dois pontos (`:`)
+
+O curinga de arquivos JAR (`-cp "lib/*"`) funciona normalmente, pois é expandido pela própria JVM.
+
+* Montar a lista de arquivos-fonte
+
+```powershell
+$sources = Get-ChildItem -Path src -Filter *.java -Recurse | ForEach-Object { $_.FullName }
+```
+
+* Compilar o código do programa e dos testes unitários. O código do teste unitário já é fornecido.
+
+```powershell
+javac -cp "lib/*" -d bin $sources
+```
+
+* Executar programa java
+
+```powershell
+java -cp bin HelloWorld
+```
+
+* Executar programa java com mais de uma entrada no classpath
+
+```powershell
+java -cp "bin;lib/*" HelloWorld
+```
+
+* Criar um jar com o programa
+
+```powershell
+jar --create --file bin\HelloWorld.jar --main-class HelloWorld -C bin\ HelloWorld.class
+```
+
+* Executar programa java por meio do jar
+
+```powershell
+java -jar bin\HelloWorld.jar
+```
+
+* Decompilar classe Java
+
+```powershell
+javap -cp bin -c HelloWorld
+```

--- a/howto/windows/04b-run-local-tests-manual-windows.md
+++ b/howto/windows/04b-run-local-tests-manual-windows.md
@@ -1,0 +1,37 @@
+### Instruções para testes locais das atividades no Windows
+
+Cada atividade é acompanhada de testes unitários. Para avaliar seu código antes de submetê-lo, execute os seguintes comandos a partir de seu diretório pessoal de cada atividade.
+
+* Criar diretório para armazenar as dependências
+
+```powershell
+New-Item -ItemType Directory -Force -Path lib
+```
+
+* Baixar o junit
+
+```powershell
+curl.exe -L -o lib\junit-platform-console-standalone-1.11.4.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.11.4/junit-platform-console-standalone-1.11.4.jar
+```
+
+No PowerShell, `curl` é um apelido para `Invoke-WebRequest`, que não reconhece as opções `-L` e `-o`. É obrigatório utilizar `curl.exe`, disponível no Windows 10 e 11.
+
+* Montar a lista de arquivos-fonte do programa e dos testes
+
+```powershell
+$sources = Get-ChildItem -Path src, ..\..\test -Filter *.java -Recurse | ForEach-Object { $_.FullName }
+```
+
+O caminho até o diretório `test` varia conforme a estrutura da atividade. Ajustar a quantidade de `..\` caso a atividade possua subdiretório numerado.
+
+* Compilar o código do programa e dos testes unitários. O código do teste unitário já é fornecido.
+
+```powershell
+javac -cp "lib/*" -d bin $sources
+```
+
+* Executar testes unitários e verificar o resultado no console
+
+```powershell
+java -jar lib\junit-platform-console-standalone-1.11.4.jar execute --class-path bin --scan-class-path
+```

--- a/howto/windows/04c-run-local-tests-with-jacoco-manual-windows.md
+++ b/howto/windows/04c-run-local-tests-with-jacoco-manual-windows.md
@@ -1,0 +1,71 @@
+### Instruções para testes locais das atividades com cobertura no Windows
+
+Cada atividade é acompanhada de testes unitários. Para avaliar seu código antes de submetê-lo, execute os seguintes comandos a partir de seu diretório pessoal de cada atividade.
+
+* Criar diretório para armazenar as dependências
+
+```powershell
+New-Item -ItemType Directory -Force -Path lib
+```
+
+* Baixar o junit
+
+```powershell
+curl.exe -L -o lib\junit-platform-console-standalone-1.11.4.jar https://repo1.maven.org/maven2/org/junit/platform/junit-platform-console-standalone/1.11.4/junit-platform-console-standalone-1.11.4.jar
+```
+
+No PowerShell, `curl` é um apelido para `Invoke-WebRequest`, que não reconhece as opções `-L` e `-o`. É obrigatório utilizar `curl.exe`, disponível no Windows 10 e 11.
+
+* Montar a lista de arquivos-fonte do programa e dos testes
+
+```powershell
+$sources = Get-ChildItem -Path src, ..\..\test -Filter *.java -Recurse | ForEach-Object { $_.FullName }
+```
+
+* Compilar o código do programa e dos testes unitários. O código do teste unitário já é fornecido.
+
+```powershell
+javac -cp "lib/*" -d bin $sources
+```
+
+* Executar testes unitários e verificar o resultado no console
+
+```powershell
+java -jar lib\junit-platform-console-standalone-1.11.4.jar execute --class-path bin --scan-class-path
+```
+
+* Baixar o JaCoCo Cli
+
+```powershell
+curl.exe -L -o lib\jacococli.jar https://repo1.maven.org/maven2/org/jacoco/org.jacoco.cli/0.8.13/org.jacoco.cli-0.8.13-nodeps.jar
+```
+
+* Baixar o JaCoCo Agent
+
+```powershell
+curl.exe -L -o lib\jacocoagent.jar https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/0.8.13/org.jacoco.agent-0.8.13-runtime.jar
+```
+
+* Rodar os testes com cobertura JaCoCo
+
+```powershell
+java -javaagent:lib\jacocoagent.jar=destfile=lib\jacoco.exec -jar lib\junit-platform-console-standalone-1.11.4.jar execute --class-path bin --scan-class-path
+```
+
+* Gerar o relatório com o JaCoCo CLI
+
+```powershell
+java -jar lib\jacococli.jar report lib\jacoco.exec --classfiles bin --sourcefiles src --html coverage-report --name "JaCoCo Coverage"
+```
+
+* Abrir o relatório de cobertura no navegador
+
+```powershell
+Start-Process coverage-report\index.html
+```
+
+* Servir relatório de cobertura via HTTP (opcional, requer Node.js instalado)
+
+```powershell
+npx http-server coverage-report 8080
+```

--- a/howto/windows/README.md
+++ b/howto/windows/README.md
@@ -1,0 +1,6 @@
+
+### Instruções sobre como configurar ferramentas no Windows
+
+Cada arquivo neste diretório contém instruções para realização de tarefas em ambiente Windows.
+
+Todos os comandos devem ser executados no **PowerShell**, não no Prompt de Comando (CMD).


### PR DESCRIPTION
Adiciona o diretorio howto/windows com a versao Windows das instrucoes do diretorio howto.

Os comandos foram adaptados para PowerShell. O winget substitui o apt, o Scoop substitui o SDKMAN e a definicao da versao padrao do Java passa pela ordem das entradas no PATH em vez do update-alternatives.

Os arquivos 01g-install-docker e 02b-install-vscode-manual estao vazios no diretorio original e foram preenchidos nas versoes Windows.

Tres comandos do material original nao funcionam no PowerShell e estao documentados:

- O PowerShell nao expande curingas como src/*.java para programas externos, entao a lista de arquivos-fonte precisa ser montada antes da chamada ao javac. O curinga de JAR em -cp "lib/*" continua funcionando porque a expansao e feita pela JVM
- O separador entre entradas de classpath e ponto e virgula em vez de dois pontos
- O comando curl e um apelido de Invoke-WebRequest e nao reconhece as opcoes -L e -o, sendo necessario invocar curl.exe

Observacao: o arquivo howto/01e-install-git.md contem o titulo e os comandos do GitHub CLI, aparentemente duplicado do 01d. O arquivo original nao foi alterado. A versao Windows correspondente traz as instrucoes do Git, incluindo user.name, user.email e core.autocrlf.
